### PR TITLE
fix(utils): resolve restore cache path

### DIFF
--- a/packages/nx-affected-matrix/src/lib/nx-affected-matrix.ts
+++ b/packages/nx-affected-matrix/src/lib/nx-affected-matrix.ts
@@ -36,7 +36,7 @@ export function chunkify<T>(arr: T[], numberOfChunks: number): T[][] {
   return result;
 }
 
-export async function generateAffectedMatrix(
+export function generateAffectedMatrix(
   { targets, maxDistribution, args = [] }: Pick<Inputs, 'targets' | 'maxDistribution' | 'args'>,
   exec: Exec
 ): Promise<NxAffectedMatrix> {

--- a/packages/nx-distributed-task/action.yml
+++ b/packages/nx-distributed-task/action.yml
@@ -9,7 +9,8 @@ inputs:
     required: true
   projects:
     description: "Comma-delimited list of projects to run against target"
-    required: true
+    required: false
+    default: ''
   distribution:
     description: "Current distribution run, required when running in a matrix"
     required: false

--- a/packages/nx-distributed-task/src/lib/inputs.ts
+++ b/packages/nx-distributed-task/src/lib/inputs.ts
@@ -22,7 +22,7 @@ export function getInputs(): Inputs {
     ...getBaseInputs(),
     target,
     distribution: getDistribution(),
-    projects: getStringArrayInput('projects', ',', { required: true }),
+    projects: getStringArrayInput('projects', ','),
     maxParallel: getMaxDistribution(target, 'maxParallel')[target],
     nxCloud: getBooleanInput('nxCloud'),
     uploadOutputs: getBooleanInput('uploadOutputs'),

--- a/packages/nx-distributed-task/src/lib/nx-distributed-task.spec.ts
+++ b/packages/nx-distributed-task/src/lib/nx-distributed-task.spec.ts
@@ -1,4 +1,5 @@
 import { restoreCache, saveCache } from '@actions/cache';
+import { logger } from '../../../utils/src/lib/__mocks__/logger';
 
 jest.mock('../../../utils/src', () => ({
   ...(jest.requireActual('../../../utils/src') as any),
@@ -8,15 +9,19 @@ jest.mock('../../../utils/src', () => ({
   getProjectOutputs: jest.fn().mockReturnValue('dist/test'),
   uploadArtifact: jest.fn().mockResolvedValue('test'),
   nxPrintAffected: jest.fn().mockResolvedValue(['project1', 'project2', 'project3', 'project4']),
+  logger,
 }));
 
 jest.mock('@actions/cache');
 
-import { assertNxInstalled, nxRunMany, uploadArtifact } from '../../../utils/src';
+import { assertNxInstalled, nxRunMany, PRIMARY_KEY, uploadArtifact } from '../../../utils/src';
 import { main } from './nx-distributed-task';
+import * as core from '@actions/core';
 
 describe('nxDistributedTask', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
+
     const env = {
       INPUT_TARGET: 'test',
       INPUT_BUCKET: '1',
@@ -43,19 +48,46 @@ describe('nxDistributedTask', () => {
     expect(uploadArtifact).toHaveBeenNthCalledWith(1, 'test', 'dist/test');
   });
 
-  it('should save cache in post job if key is available', async () => {
-    process.env = { ...process.env, [`STATE_isPostJob`]: 'true', STATE_cacheKey: 'test' };
-
-    (saveCache as jest.Mock).mockClear();
-    (assertNxInstalled as jest.Mock).mockClear();
-    (nxRunMany as jest.Mock).mockClear();
-    (uploadArtifact as jest.Mock).mockClear();
+  it('should exit if no projects to run', async () => {
+    process.env['INPUT_PROJECTS'] = undefined;
 
     await main();
 
-    expect(saveCache).toHaveBeenCalled();
     expect(assertNxInstalled).not.toHaveBeenCalled();
-    expect(nxRunMany).not.toHaveBeenCalled();
+  });
+
+  it('should not upload artifacts', async () => {
+    process.env['INPUT_UPLOADOUTPUTS'] = 'false';
+
+    await main();
+
+    expect(assertNxInstalled).toHaveBeenCalled();
     expect(uploadArtifact).not.toHaveBeenCalled();
+  });
+
+  it('should set job as failed if any unhandled error occurs', async () => {
+    (assertNxInstalled as jest.Mock).mockRejectedValue('test');
+    const spy = jest.spyOn(core, 'setFailed');
+    await main();
+
+    expect(spy).toHaveBeenCalledWith('test');
+  });
+
+  describe('post job', () => {
+    it('should save cache if key is available', async () => {
+      process.env = { ...process.env, [`STATE_isPostJob`]: 'true', [`STATE_${PRIMARY_KEY}`]: 'test' };
+
+      (saveCache as jest.Mock).mockClear();
+      (assertNxInstalled as jest.Mock).mockClear();
+      (nxRunMany as jest.Mock).mockClear();
+      (uploadArtifact as jest.Mock).mockClear();
+
+      await main();
+
+      expect(saveCache).toHaveBeenCalled();
+      expect(assertNxInstalled).not.toHaveBeenCalled();
+      expect(nxRunMany).not.toHaveBeenCalled();
+      expect(uploadArtifact).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/utils/__mocks__/@actions/cache.ts
+++ b/packages/utils/__mocks__/@actions/cache.ts
@@ -1,5 +1,5 @@
-export const restoreCache = jest.fn().mockResolvedValue('');
+export const restoreCache = jest.fn().mockResolvedValue('test');
 
-export const saveCache = jest.fn().mockResolvedValue('');
+export const saveCache = jest.fn().mockResolvedValue('test');
 
 export { ReserveCacheError } from '@actions/cache';

--- a/packages/utils/src/lib/__mocks__/fs.ts
+++ b/packages/utils/src/lib/__mocks__/fs.ts
@@ -45,4 +45,5 @@ export const tree = {
         ['workspace.json', 'angular.json'].some((file) => path.includes(file)) ? workspaceMock : projectConfigMock
       )
     ),
+  getLockFilePath: jest.fn().mockReturnValue('package-lock.json'),
 };

--- a/packages/utils/src/lib/artifact.spec.ts
+++ b/packages/utils/src/lib/artifact.spec.ts
@@ -1,17 +1,49 @@
 import { uploadArtifact } from './artifact';
 import { create } from '@actions/glob';
+import { create as aCreate } from '@actions/artifact';
+import { logger } from './logger';
 
 describe('artifact', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (create as jest.Mock).mockResolvedValue({ glob: jest.fn().mockResolvedValue(['dis/test1', 'dist/test2']) });
+  });
+
   it('should not upload if no paths', async () => {
     await expect(uploadArtifact('test', [])).resolves.toBeUndefined();
   });
 
   it('should not upload if not found files', async () => {
+    (create as jest.Mock).mockResolvedValue({ glob: jest.fn().mockResolvedValue([]) });
     await expect(uploadArtifact('test', ['dist'])).resolves.toBeUndefined();
   });
 
   it('should upload files', async () => {
-    (create as jest.Mock).mockResolvedValue({ glob: jest.fn().mockResolvedValue(['dis/test1', 'dist/test2']) });
     await expect(uploadArtifact('test', ['dist'])).resolves.toBe('test');
+  });
+
+  it('should skip upload if debug mode is on', async () => {
+    const uploadSpy = jest.fn();
+    (aCreate as jest.Mock).mockImplementationOnce(() => ({
+      uploadArtifact: uploadSpy,
+    }));
+
+    logger.debugMode = true;
+
+    await expect(uploadArtifact('test', ['dist'])).resolves.toBeUndefined();
+    expect(uploadSpy).not.toHaveBeenCalled();
+
+    logger.debugMode = false;
+  });
+
+  it('should fail uploading silently', async () => {
+    (aCreate as jest.Mock).mockImplementationOnce(() => ({
+      uploadArtifact: jest.fn().mockRejectedValue('test'),
+    }));
+    const loggerSpy = jest.spyOn(logger, 'warning');
+
+    await uploadArtifact('test', ['dist']);
+
+    expect(loggerSpy).toHaveBeenCalled();
   });
 });

--- a/packages/utils/src/lib/cache.spec.ts
+++ b/packages/utils/src/lib/cache.spec.ts
@@ -1,71 +1,105 @@
-import { getCacheKeys, NX_CACHE_PATH, restoreNxCache, saveNxCache } from './cache';
-import { context } from '@actions/github';
-import { saveCache, restoreCache, ReserveCacheError } from '@actions/cache';
+import { NX_CACHE_PATH, restoreNxCache, saveNxCache, PRIMARY_KEY, CACHE_KEY } from './cache';
 import { resolve } from 'path';
+import { tree } from './fs';
+
+import { saveCache, restoreCache, ReserveCacheError } from '@actions/cache';
+import { logger } from './logger';
 
 describe('cache', () => {
-  process.env.RUNNER_OS = process.env.RUNNER_OS || process.platform;
-  process.env.RUNNER_ARCH = process.env.RUNNER_ARCH || process.arch;
-
-  beforeEach(() => {
-    (restoreCache as jest.Mock).mockClear();
-    (saveCache as jest.Mock).mockClear();
+  beforeAll(() => {
+    process.env.RUNNER_OS = process.env.RUNNER_OS || process.platform;
+    process.env.RUNNER_ARCH = process.env.RUNNER_ARCH || process.arch;
   });
 
-  describe('getCacheKeys', () => {
-    it('should create primary key composed of platform, arch, date, target, distribution and pr', async () => {
-      const [primary] = await getCacheKeys('test', 5);
-      const now = new Date();
-      expect(primary).toContain(`${process.env.RUNNER_OS}-`);
-      expect(primary).toContain(`-${process.env.RUNNER_ARCH}-`);
-      expect(primary).toContain(`-${now.getFullYear()}-${now.getMonth() + 1}-`);
-      expect(primary).toContain(`-test-`);
-      expect(primary).toContain(`-5-`);
-      expect(primary).toContain(`-${context.payload.pull_request.number.toString()}`);
-    });
-
-    it('should create restore keys variations without pr, distribution and target', async () => {
-      const [_, [withoutPR, withoutBucket, withoutTarget]] = await getCacheKeys('test', 5);
-      // withoutPR
-      expect(withoutPR).not.toContain(`-${context.payload.pull_request.number.toString()}`);
-      expect(withoutPR).toContain(`-5`);
-      // withoutBucket
-      expect(withoutBucket).not.toContain(`-${context.payload.pull_request.number.toString()}`);
-      expect(withoutBucket).not.toContain(`-5-`);
-      expect(withoutPR).toContain(`-test`);
-      // withoutTarget
-      expect(withoutTarget).not.toContain(`-${context.payload.pull_request.number.toString()}`);
-      expect(withoutTarget).not.toContain(`-5-`);
-      expect(withoutTarget).not.toContain(`-test-`);
-    });
+  beforeEach(() => {
+    jest.spyOn(tree, 'getLockFilePath').mockReturnValue('package-lock.json');
+    jest.clearAllMocks();
   });
 
   describe('restoreNxCache', () => {
     it('should restore cache with primary key and restoreKeys', async () => {
-      await restoreNxCache('test', ['test2']);
-      expect(restoreCache).toHaveBeenCalledWith([NX_CACHE_PATH], 'test', ['test2']);
+      await restoreNxCache('test', 2);
+      expect(restoreCache).toHaveBeenCalledWith(
+        [resolve(NX_CACHE_PATH)],
+        expect.stringContaining('test-2'),
+        expect.arrayContaining([expect.stringContaining('test')])
+      );
     });
 
     it('should fail silently', async () => {
-      (restoreCache as jest.Mock).mockRejectedValue('');
-      await expect(restoreNxCache('test', ['test2'])).resolves.toBeUndefined();
+      (restoreCache as jest.Mock).mockRejectedValueOnce('');
+      const warningSpy = jest.spyOn(logger, 'warning');
+
+      await restoreNxCache('test', 2);
+
+      expect(warningSpy).toHaveBeenCalledWith('');
+    });
+
+    it('should report cache miss', async () => {
+      (restoreCache as jest.Mock).mockResolvedValueOnce('');
+      const infoSpy = jest.spyOn(logger, 'info');
+
+      await restoreNxCache('test', 2);
+
+      expect(infoSpy).toHaveBeenCalledWith('Cache miss');
+    });
+
+    it('should not restore cache if in debug mode', async () => {
+      logger.debugMode = true;
+
+      await restoreNxCache('test', 2);
+
+      expect(restoreCache).not.toHaveBeenCalled();
+
+      logger.debugMode = false;
     });
   });
 
   describe('saveNxCache', () => {
+    beforeEach(() => {
+      process.env[`STATE_${PRIMARY_KEY}`] = 'test';
+      jest.clearAllMocks();
+    });
+
     it('should save cache with primary key', async () => {
-      await saveNxCache('test');
+      await saveNxCache();
       expect(saveCache).toHaveBeenCalledWith([resolve(NX_CACHE_PATH)], 'test');
     });
 
     it('should fail silently for ReserveCacheError', async () => {
       (saveCache as jest.Mock).mockRejectedValueOnce(new ReserveCacheError('test'));
-      await expect(saveNxCache('test')).resolves.toBeUndefined();
+      await expect(saveNxCache()).resolves.toBeUndefined();
     });
 
     it('should fail for not ReserveCacheError', async () => {
       (saveCache as jest.Mock).mockRejectedValueOnce(new Error('test'));
-      await expect(saveNxCache('test')).rejects.toThrowError('test');
+      await expect(saveNxCache()).rejects.toThrowError('test');
+    });
+
+    it('should not save cache if in debug mode', async () => {
+      logger.debugMode = true;
+
+      await saveNxCache();
+
+      expect(saveCache).not.toHaveBeenCalled();
+
+      logger.debugMode = false;
+    });
+
+    it('should not save if no primary key is provided', async () => {
+      process.env[`STATE_${PRIMARY_KEY}`] = '';
+
+      await saveNxCache();
+
+      expect(saveCache).not.toHaveBeenCalled();
+    });
+
+    it('should not save if cache hit occurred on primary key', async () => {
+      process.env[`STATE_${CACHE_KEY}`] = 'test';
+
+      await saveNxCache();
+
+      expect(saveCache).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/utils/src/lib/exec.spec.ts
+++ b/packages/utils/src/lib/exec.spec.ts
@@ -30,4 +30,14 @@ describe('exec', () => {
       listeners: { stdout: expect.any(Function), stderr: expect.any(Function) },
     });
   });
+
+  it('should throw if no command is specified', async () => {
+    exec = new Exec();
+
+    try {
+      exec.build();
+    } catch (e) {
+      expect(e.message).toBe('No command given to Exec');
+    }
+  });
 });

--- a/packages/utils/src/lib/logger.ts
+++ b/packages/utils/src/lib/logger.ts
@@ -1,7 +1,13 @@
 import { info, debug, warning, error, notice, AnnotationProperties, group, isDebug } from '@actions/core';
 
 class Logger {
-  debugMode = false;
+  private _debugMode = false;
+  set debugMode(value: boolean) {
+    this._debugMode = value;
+  }
+  get debugMode(): boolean {
+    return this._debugMode;
+  }
 
   log(message: string) {
     info(message);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: [CONTRIBUTING.md](CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When trying to restore the cache, the path to the cache is not being resolved but in saving it does, which causes a cache miss.
Also the action tries to save cache when it was restored from the primary key which results in a ReserveCacheError being thrown

Issue Number: N/A

## What is the new behavior?

The path to the cache is being resolved in both saving and restoring the cache.
The action will skip saving cache if it was restored from the primary key (which is the same behavior of  GH's `@actions/cache`.

Also some code was refactored and removed unneeded `async` from functions, it should remove some boilerplate code from the final build

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
