### PR TITLE
fix(utils): configuration is not parsed from args & args name format

### DIFF
--- a/packages/nx-distributed-task/src/app/nx.ts
+++ b/packages/nx-distributed-task/src/app/nx.ts
@@ -1,12 +1,14 @@
+import * as _Exec from '@actions/exec';
 import type { context as Context } from '@actions/github';
+import { getPackageManagerCommand, getPackageManagerVersion } from '@nrwl/tao/src/shared/package-manager';
+import { NxArgs } from '@nrwl/workspace/src/command-line/utils';
+import { names } from '@nrwl/devkit/src/utils/names';
 
 import { Exec } from '@e-square/utils/exec';
 import { BaseInputs } from '@e-square/utils/inputs';
 import { debug, group, logger } from '@e-square/utils/logger';
-import * as _Exec from '@actions/exec';
+
 import { Inputs } from './inputs';
-import { getPackageManagerCommand, getPackageManagerVersion } from '@nrwl/tao/src/shared/package-manager';
-import { NxArgs } from '@nrwl/workspace/src/command-line/utils';
 
 export async function assertNxInstalled(exec: Exec) {
   debug(`Checking existence of nx`);
@@ -26,7 +28,9 @@ export async function nxCommand(nxCommand: string, target: string, exec: Exec, a
     .withCommand(`${command} -p @nrwl/cli nx ${nxCommand}`)
     .withArgs(
       `--target=${target}`,
-      ...Object.entries(args).map(([k, v]) => (typeof v === 'boolean' && v ? `--${k}` : `--${k}=${v}`))
+      ...Object.entries(args).map(([k, v]) =>
+        typeof v === 'boolean' && v ? `--${names(k).fileName}` : `--${names(k).fileName}=${v}`
+      )
     )
     .build();
 

--- a/packages/utils/src/lib/inputs.ts
+++ b/packages/utils/src/lib/inputs.ts
@@ -25,7 +25,9 @@ export function getArgsInput(
   mode: Parameters<typeof splitArgsIntoNxArgsAndOverrides>[1] = 'print-affected',
   options?: Core.InputOptions
 ): NxArgs {
-  const args = getStringArrayInput(core, 'args', /[= ]/g, options);
+  const args = getStringArrayInput(core, 'args', /[= ]/g, options).map((arg) =>
+    arg === '-c' ? '--configuration' : arg
+  );
   return (
     splitArgsIntoNxArgsAndOverrides({ _: args, $0: '' }, mode, {
       printWarnings: false,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: [CONTRIBUTING.md](CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`-c` arg is being ignored when parsed to NxArgs

## What is the new behavior?
`-c` will be replaced with `--configuration` so it will be parsed correctly
## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```