### PR TITLE
fix: with-deps removed in nx 14

### DIFF
--- a/packages/nx-distributed-task/src/app/nx.ts
+++ b/packages/nx-distributed-task/src/app/nx.ts
@@ -23,9 +23,12 @@ export async function getNxVersion(exec: Exec): Promise<string> {
 
 export async function nxCommand(nxCommand: string, args: NxArgs, exec: Exec): Promise<string> {
   const [nxMajorVersion] = (await getNxVersion(exec)).split('.');
-  // override with-deps because it was removed in NX 14
-  if (nxMajorVersion < '14' && args.withDeps) {
+  if (args.withDeps) {
     warning(`with-deps was removed in NX 14. Please replace its usage with 'targetDefaults'`);
+  }
+
+  // override with-deps because it was removed in NX 14
+  if (nxMajorVersion >= '14') {
     args.withDeps = undefined;
     args['with-deps'] = undefined;
   }

--- a/packages/nx-distributed-task/src/app/nx.ts
+++ b/packages/nx-distributed-task/src/app/nx.ts
@@ -18,7 +18,8 @@ export async function assertNxInstalled(exec: Exec) {
 }
 
 export async function getNxVersion(exec: Exec): Promise<string> {
-  return await exec.withCommand(`nx --version`).build()();
+  const command = getPackageManagerCommand().exec;
+  return await exec.withCommand(`${command} nx --version`).build()();
 }
 
 export async function nxCommand(nxCommand: string, args: NxArgs, exec: Exec): Promise<string> {

--- a/packages/nx-distributed-task/src/app/nx.ts
+++ b/packages/nx-distributed-task/src/app/nx.ts
@@ -4,7 +4,7 @@ import { NxArgs } from '@nrwl/workspace/src/command-line/utils';
 import { names } from '@nrwl/devkit/src/utils/names';
 
 import { Exec } from '@e-square/utils/exec';
-import { debug, group, logger } from '@e-square/utils/logger';
+import { debug, group, logger, warning } from '@e-square/utils/logger';
 
 export async function assertNxInstalled(exec: Exec) {
   const command = getPackageManagerCommand().list;
@@ -17,7 +17,19 @@ export async function assertNxInstalled(exec: Exec) {
   if (!path) throw new Error("Couldn't find Nx binary, Have you run npm/yarn install?");
 }
 
+export async function getNxVersion(exec: Exec): Promise<string> {
+  return await exec.withCommand(`nx --version`).build()();
+}
+
 export async function nxCommand(nxCommand: string, args: NxArgs, exec: Exec): Promise<string> {
+  const [nxMajorVersion] = (await getNxVersion(exec)).split('.');
+  // override with-deps because it was removed in NX 14
+  if (nxMajorVersion < '14' && args.withDeps) {
+    warning(`with-deps was removed in NX 14. Please replace its usage with 'targetDefaults'`);
+    args.withDeps = undefined;
+    args['with-deps'] = undefined;
+  }
+
   const [pmMajorVersion] = getPackageManagerVersion().split('.');
   let command = getPackageManagerCommand().exec;
   const isNpx = command === 'npx';

--- a/packages/utils/src/lib/inputs.ts
+++ b/packages/utils/src/lib/inputs.ts
@@ -52,8 +52,14 @@ export function parseNxArgs(args: Record<string, unknown>): NxArgs {
 
 export function shouldRunWithDeps(target: string): boolean {
   const nxJson = readNxJson(tree);
-
-  return Boolean(nxJson?.targetDependencies?.[target]?.some?.(({ projects }) => projects === 'dependencies'));
+  const isNx14 = (nxJson as any).targetDefaults !== undefined;
+  if (isNx14) {
+    return Boolean(
+      ((nxJson as any)?.targetDefaults?.[target]?.dependsOn as string[]).some?.((dep) => dep.includes(target))
+    );
+  } else {
+    return Boolean(nxJson?.targetDependencies?.[target]?.some?.(({ projects }) => projects === 'dependencies'));
+  }
 }
 
 export function getArgsInput(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: [CONTRIBUTING.md](CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
with-deps argument is being added to every command whether its true or false
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

added support for checking if should use withDeps for dependency graph for nx 14
removed with-deps arg from nxCommand explicitly in nx 14

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
